### PR TITLE
Fix to use setOptions() syntax

### DIFF
--- a/src/Bt51/Silex/Provider/StashServiceProvider/StashServiceProvider.php
+++ b/src/Bt51/Silex/Provider/StashServiceProvider/StashServiceProvider.php
@@ -26,8 +26,9 @@ class StashServiceProvider implements ServiceProviderInterface
         $app['stash.driver'] = $app->share(function ($app) {
             $options = (isset($app['stash.driver.options']) ? $app['stash.driver.options'] : array());
             $class = sprintf('\\Stash\\Driver\\%s', $app['stash.driver.class']);
-            $driver = new \ReflectionClass($class);
-            return $driver->newInstanceArgs(array($options));
+            $driver  = new $class;
+            $driver->setOptions($options);
+            return $driver;            
         });
         
         $app['stash'] = $app->share(function ($app) {


### PR DESCRIPTION
This allows the provider to use the new setOptions() syntax, as opposed to passing the options in via the constructor, which is no longer supported.
