### PR TITLE
Updated the serviceprovider to reflect Stash API changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 	],
 	"require": {
 		"php": ">=5.3.2",
-		"tedivm/stash": "~0.12"
+		"tedivm/stash": "~0.14"
 	},
 	"require-dev": {
         "silex/silex": "1.1.*",

--- a/src/StashServiceProvider.php
+++ b/src/StashServiceProvider.php
@@ -26,8 +26,7 @@ class StashServiceProvider implements ServiceProviderInterface
         $app['stash.driver'] = $app->share(function ($app) {
             $options = (isset($app['stash.driver.options']) ? $app['stash.driver.options'] : array());
             $class = sprintf('\\Stash\\Driver\\%s', $app['stash.driver.class']);
-            $driver  = new $class;
-            $driver->setOptions($options);
+            $driver  = new $class($options);
             return $driver;            
         });
         


### PR DESCRIPTION
Stash 0.14 has changes in the API (https://github.com/tedious/Stash/releases/tag/v0.14.1): setOptions() is removed. Stash 0.14 or higher is now required with this change.
